### PR TITLE
removing the restriction of only using a rule once in a proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Codecov](https://img.shields.io/codecov/c/github/chanind/fuzzy-reasoner/main)](https://codecov.io/gh/chanind/fuzzy-reasoner)
 [![PyPI](https://img.shields.io/pypi/v/fuzzy-reasoner?color=blue)](https://pypi.org/project/fuzzy-reasoner/)
 
-
 A simple symbolic reasoner which allows fuzzy unification based on embedding comparisons.
 
 This projects takes ideas and inspiration from the following papers:
@@ -24,9 +23,7 @@ pip install fuzzy-reasoner
 
 This library is still very much in beta and may change its public API at any time before reaching version 1.0, so it's recommended to pin the exact version before then.
 
-This library is currently limited to only use a rule once in a proof as a way to avoid cycles in the proof graph. This restriction should be fixed soon though, as this restriction does limit the usefulness of the library.
-
-This library is pure Python, and is not highly optimized code. If you need a high-performance mature solver this package is likely not a great fit. However, pull requests are welcome if you'd like to contribute and help make this library higher-performance!
+This library is pure Python, and is not highly optimized code. If you need a high-performance solver this package is likely not a great fit. However, pull requests are welcome if there are any improvements you'd like to make!
 
 ## Usage
 

--- a/fuzzy_reasoner/prover/Goal.py
+++ b/fuzzy_reasoner/prover/Goal.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from fuzzy_reasoner.types.Atom import Atom
-from fuzzy_reasoner.types.Rule import Rule
 
 
 @dataclass(frozen=True, eq=False)
 class Goal:
     statement: Atom
-    scope: Rule
+    scope: int
 
     def __str__(self) -> str:
         return f"GOAL:{self.statement}"

--- a/fuzzy_reasoner/prover/ProofGraph.py
+++ b/fuzzy_reasoner/prover/ProofGraph.py
@@ -13,6 +13,7 @@ from fuzzy_reasoner.types.Variable import Variable
 @dataclass(frozen=True, eq=False)
 class ProofGraphNode:
     goal: Atom
+    scope: int
     rule: Rule
     unification_similarity: float
     overall_similarity: float
@@ -38,6 +39,6 @@ class ProofGraph:
         for term in self.goal.terms:
             if isinstance(term, Variable):
                 bindings[term] = resolve_term(
-                    term, self.head.rule, self.head.substitutions
+                    term, self.head.scope, self.head.substitutions
                 )
         return Map(bindings)

--- a/fuzzy_reasoner/prover/ProofState.py
+++ b/fuzzy_reasoner/prover/ProofState.py
@@ -3,12 +3,8 @@ from dataclasses import dataclass
 from immutables import Map
 from fuzzy_reasoner.prover.operations.substitution import SubstitutionsMap
 
-from fuzzy_reasoner.types.Rule import Rule
-
 
 @dataclass
 class ProofState:
     similarity: float = 1.0
     substitutions: SubstitutionsMap = Map()
-    # TODO: allow re-using rules, find another way to avoid cycles in the proof graph
-    available_rules: frozenset[Rule] = frozenset()

--- a/fuzzy_reasoner/prover/SLDProver.py
+++ b/fuzzy_reasoner/prover/SLDProver.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 from fuzzy_reasoner.prover.Goal import Goal
 from fuzzy_reasoner.prover.ProofState import ProofState
 from fuzzy_reasoner.prover.operations.recurse import recurse
+from fuzzy_reasoner.prover.operations.substitution import generate_variable_scope
 from fuzzy_reasoner.similarity import SimilarityFunc, cosine_similarity
 
 from fuzzy_reasoner.types.Atom import Atom
@@ -38,12 +39,17 @@ class SLDProver:
     def prove_all(
         self, goal: Goal | Atom, dynamic_rules: Optional[Sequence[Rule]] = None
     ) -> list[ProofGraph]:
-        adjusted_goal = goal if isinstance(goal, Goal) else Goal(goal, scope=Rule(goal))
+        adjusted_goal = (
+            goal
+            if isinstance(goal, Goal)
+            else Goal(goal, scope=generate_variable_scope())
+        )
         rules = self.rules.union(dynamic_rules) if dynamic_rules else self.rules
         _successful_proof_states, successful_graph_nodes = recurse(
             adjusted_goal,
             self.max_proof_depth,
-            ProofState(available_rules=rules),
+            ProofState(),
+            rules,
             self.similarity_func,
             self.min_similarity_threshold,
         )

--- a/fuzzy_reasoner/prover/operations/substitution.py
+++ b/fuzzy_reasoner/prover/operations/substitution.py
@@ -3,21 +3,30 @@ from typing import Tuple, Union
 from immutables import Map
 
 from fuzzy_reasoner.types.Constant import Constant
-from fuzzy_reasoner.types.Rule import Rule
 from fuzzy_reasoner.types.Variable import Variable
 
 
 # using from __future__ import annotations with | doesn't work here
 # I think because this is declaring a type as a variable
-SubstitutionsMap = Map[Rule, Map[Variable, Union[Constant, Tuple[Rule, Variable]]]]
+SubstitutionsMap = Map[int, Map[Variable, Union[Constant, Tuple[int, Variable]]]]
 
 
 class VariableBindingError(Exception):
     pass
 
 
+_count = 0
+
+
+def generate_variable_scope() -> int:
+    """simple helper to output different int each time its called to use as a scope for variable binding"""
+    global _count
+    _count += 1
+    return _count
+
+
 def resolve_term(
-    term: Variable | Constant, scope: Rule, substitutions: SubstitutionsMap
+    term: Variable | Constant, scope: int, substitutions: SubstitutionsMap
 ) -> Variable | Constant:
     """
     if this term is a variable that's already been bound to a constant in the substitutions map, swap it for its bound value
@@ -30,13 +39,13 @@ def resolve_term(
 
 
 def is_var_bound(
-    variable: Variable, scope: Rule, substitutions: SubstitutionsMap
+    variable: Variable, scope: int, substitutions: SubstitutionsMap
 ) -> bool:
     return bool(get_var_binding(variable, scope, substitutions))
 
 
 def get_var_binding(
-    variable: Variable, scope: Rule, substitutions: SubstitutionsMap
+    variable: Variable, scope: int, substitutions: SubstitutionsMap
 ) -> Constant | None:
     """Return the currently bound constant for this variable if already bound, or None if not bound yet"""
     scope_bindings = substitutions.get(scope)
@@ -51,9 +60,9 @@ def get_var_binding(
 
 def set_var_binding(
     variable: Variable,
-    scope: Rule,
+    scope: int,
     # tuple[rule, var] represents the path to look up that variable recursively in the substitutions mapping
-    value: Constant | tuple[Rule, Variable],
+    value: Constant | tuple[int, Variable],
     substitutions: SubstitutionsMap,
 ) -> SubstitutionsMap:
     scope_bindings = substitutions.get(scope)

--- a/fuzzy_reasoner/prover/operations/unify.py
+++ b/fuzzy_reasoner/prover/operations/unify.py
@@ -17,6 +17,7 @@ from fuzzy_reasoner.types.Variable import Variable
 def unify(
     rule: Rule,
     goal: Goal,
+    scope: int,
     substitutions: SubstitutionsMap,
     similarity_func: Optional[SimilarityFunc] = None,
     min_similarity_threshold: float = 0.5,
@@ -45,19 +46,19 @@ def unify(
         return None
 
     for head_term, goal_term in zip(head.terms, goal.statement.terms):
-        head_term_resolution = resolve_term(head_term, rule, next_substitutions)
+        head_term_resolution = resolve_term(head_term, scope, next_substitutions)
         goal_term_resolution = resolve_term(goal_term, goal.scope, next_substitutions)
         if isinstance(head_term_resolution, Variable):
             # fail unification if it requires rebinding an already bound variable
-            if is_var_bound(head_term_resolution, rule, next_substitutions):
+            if is_var_bound(head_term_resolution, scope, next_substitutions):
                 return None
-            target_value: Constant | tuple[Rule, Variable] = (
+            target_value: Constant | tuple[int, Variable] = (
                 goal_term_resolution
                 if isinstance(goal_term_resolution, Constant)
                 else (goal.scope, goal_term_resolution)
             )
             next_substitutions = set_var_binding(
-                head_term_resolution, rule, target_value, next_substitutions
+                head_term_resolution, scope, target_value, next_substitutions
             )
         elif isinstance(goal_term_resolution, Variable):
             # fail unification if it requires rebinding an already bound variable

--- a/tests/prover/operations/test_substitution.py
+++ b/tests/prover/operations/test_substitution.py
@@ -10,76 +10,62 @@ from fuzzy_reasoner.prover.operations.substitution import (
     set_var_binding,
 )
 from fuzzy_reasoner.types.Constant import Constant
-from fuzzy_reasoner.types.Predicate import Predicate
-from fuzzy_reasoner.types.Rule import Rule
 from fuzzy_reasoner.types.Variable import Variable
 
 
 def test_get_var_binding_recursively_resolves_dependencies() -> None:
-    predicate = Predicate("is")
     const1 = Constant("jared")
-    const2 = Constant("mark")
     var1 = Variable("X")
     var2 = Variable("Y")
-    rule1 = Rule(predicate(const1))
-    rule2 = Rule(predicate(const2))
     subs: SubstitutionsMap = Map(
         {  # type: ignore
-            rule1: Map({var1: const1, var2: (rule2, var1)}),
-            rule2: Map({var2: (rule1, var1)}),
+            3: Map({var1: const1, var2: (7, var1)}),
+            7: Map({var2: (3, var1)}),
         }
     )
-    assert get_var_binding(var1, rule1, subs) == const1
-    assert get_var_binding(var2, rule1, subs) is None
-    assert get_var_binding(var2, rule2, subs) == const1
+    assert get_var_binding(var1, 3, subs) == const1
+    assert get_var_binding(var2, 3, subs) is None
+    assert get_var_binding(var2, 7, subs) == const1
 
 
 # -- set_var_binding helper --
 
 
 def test_set_var_binding_can_set_var_to_another_var() -> None:
-    predicate = Predicate("is")
-    const1 = Constant("jared")
     var1 = Variable("X")
     var2 = Variable("Y")
-    rule1 = Rule(predicate(const1))
     subs: SubstitutionsMap = Map()
 
-    new_subs = set_var_binding(var1, rule1, (rule1, var2), subs)
+    new_subs = set_var_binding(var1, 3, (3, var2), subs)
 
     # should recursively find the first referenced var and set its subtitution
-    assert new_subs[rule1][var1] == (rule1, var2)
+    assert new_subs[3][var1] == (3, var2)
 
 
 def test_set_var_binding_recursively_resolves_dependencies() -> None:
-    predicate = Predicate("is")
     const1 = Constant("jared")
     const2 = Constant("mark")
     var1 = Variable("X")
     var2 = Variable("Y")
-    rule1 = Rule(predicate(const1))
-    rule2 = Rule(predicate(const2))
     subs: SubstitutionsMap = Map(
         {  # type: ignore
-            rule1: Map({var1: const1, var2: (rule2, var1)}),
-            rule2: Map({var2: (rule1, var1)}),
+            3: Map({var1: const1, var2: (7, var1)}),
+            7: Map({var2: (3, var1)}),
         }
     )
 
-    new_subs = set_var_binding(var1, rule2, const2, subs)
+    new_subs = set_var_binding(var1, 7, const2, subs)
 
     # should recursively find the first referenced var and set its subtitution
-    assert new_subs[rule2][var1] == const2
-    assert get_var_binding(var1, rule2, new_subs) == const2
+    assert new_subs[7][var1] == const2
+    assert get_var_binding(var1, 7, new_subs) == const2
 
 
 def test_set_var_binding_raises_exception_when_binding_already_bound_var() -> None:
-    predicate = Predicate("is")
     const1 = Constant("jared")
     var1 = Variable("X")
     var2 = Variable("Y")
-    rule1 = Rule(predicate(const1))
-    subs: SubstitutionsMap = Map({rule1: Map({var1: const1})})
+    subs: SubstitutionsMap = Map({3: Map({var1: const1})})
 
     with pytest.raises(VariableBindingError):
-        set_var_binding(var1, rule1, (rule1, var2), subs)
+        set_var_binding(var1, 3, (3, var2), subs)

--- a/tests/prover/operations/test_unify.py
+++ b/tests/prover/operations/test_unify.py
@@ -13,6 +13,9 @@ from fuzzy_reasoner.types.Rule import Rule
 from fuzzy_reasoner.types.Variable import Variable
 
 
+scope = 7  # scope is just a number to identify variable bindings
+
+
 def test_unify_returns_new_substitution_map_and_similarity_on_success() -> None:
     is_dog = Predicate("is_dog")
     X = Variable("X")
@@ -21,17 +24,18 @@ def test_unify_returns_new_substitution_map_and_similarity_on_success() -> None:
     rule1 = Rule(is_dog(X))
     rule2 = Rule(is_dog(fluffy))
 
-    goal = Goal(rule1.head, rule1)
+    goal = Goal(rule1.head, scope)
 
     result = unify(
         rule2,
         goal,
+        scope,
         Map(),
         similarity_func=cosine_similarity,
         min_similarity_threshold=0.5,
     )
     assert result is not None
-    assert result[0] == Map({rule1: Map({X: fluffy})})
+    assert result[0] == Map({scope: Map({X: fluffy})})
     assert result[1] == 1.0
 
 
@@ -44,12 +48,13 @@ def test_unify_fails_if_similarity_is_below_threshold() -> None:
     rule1 = Rule(is_person(X))
     rule2 = Rule(is_dog(fluffy))
 
-    goal = Goal(rule1.head, rule1)
+    goal = Goal(rule1.head, scope)
 
     assert (
         unify(
             rule2,
             goal,
+            scope,
             Map(),
             similarity_func=cosine_similarity,
             min_similarity_threshold=0.9,
@@ -68,12 +73,13 @@ def test_unify_fails_if_the_terms_are_different_lengths() -> None:
     rule1 = Rule(is_doggo(X))
     rule2 = Rule(is_dog(fluffy, face))
 
-    goal = Goal(rule1.head, rule1)
+    goal = Goal(rule1.head, scope)
 
     assert (
         unify(
             rule2,
             goal,
+            scope,
             Map(),
             similarity_func=cosine_similarity,
             min_similarity_threshold=0.1,
@@ -91,11 +97,12 @@ def test_unify_uses_the_min_similarity_of_all_unified_items() -> None:
     rule1 = Rule(is_doggo(furball))
     rule2 = Rule(is_dog(fluffy))
 
-    goal = Goal(rule1.head, rule1)
+    goal = Goal(rule1.head, scope)
 
     result = unify(
         rule2,
         goal,
+        scope,
         Map(),
         similarity_func=cosine_similarity,
         min_similarity_threshold=0.1,


### PR DESCRIPTION
This PR removes the limitation that each rule can only occur one time in a proof. It's possible for there to be infinite loops in the proof graph, but there's a max proof depth so for now that's not an issue. However, in the future it would be better to add proper cycle detection as a performance improvement