### PR TITLE
chore: add a codecov.yaml for more control over coverage behavior

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 96
+        threshold: 2
+    patch:
+      default:
+        target: 96
+        threshold: 2


### PR DESCRIPTION
This should help make codecov reports less noisy