### PR TITLE
feat: simplifying the API around adding a knowledge base to the prover

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bart = Constant("bart", np.array([ ... ]))
 homer = Constant("homer", np.array([ ... ]))
 abe = Constant("abe", np.array([ ... ]))
 
-rules = [
+knowledge = [
     # base facts
     Rule(parent_of(homer, bart)),
     Rule(father_of(abe, homer)),
@@ -55,7 +55,7 @@ rules = [
     Rule(grandpa_of(X, Y), (father_of(X, Z), parent_of(Z, Y)))
 ]
 
-reasoner = SLDReasoner(rules=rules)
+reasoner = SLDReasoner(knowledge=knowledge)
 
 # query the reasoner to find who is bart's grandfather
 proof = reasoner.prove(grandfather_of(X, bart))
@@ -107,13 +107,13 @@ is_male = Predicate("is_male")
 bart = Constant("bart")
 homer = Constant("homer")
 
-rules = [
-    Rule(parent_of(homer, bart)),
-    Rule(is_male(homer)),
+knowledge = [
+    parent_of(homer, bart),
+    is_male(homer),
     Rule(father_of(X, Y), (parent_of(X, Y), is_male(X))),
 ]
 
-prover = SLDProver(rules=rules)
+prover = SLDProver(knowledge=knowledge)
 goal = father_of(homer, X)
 
 proof = prover.prove(goal)
@@ -154,13 +154,13 @@ def fancy_similarity(item1, item2):
     norm = np.linalg.norm(item1.vector) + np.linalg.norm(item2.vector)
     return np.linalg.norm(item1.vector - item2.vector) / norm
 
-reasoner = SLDReasoner(rules=rules, similarity_func=fancy_similarity)
+reasoner = SLDReasoner(knowledge=knowledge, similarity_func=fancy_similarity)
 ```
 
 By default, there is a minimum similarity threshold of `0.5` for a unification to success. You can customize this as well when creating a `SLDReasoner` instance
 
 ```python
-reasoner = SLDReasoner(rules=rules, min_similarity_threshold=0.9)
+reasoner = SLDReasoner(knowledge=knowledge, min_similarity_threshold=0.9)
 ```
 
 ### Max proof depth
@@ -168,7 +168,7 @@ reasoner = SLDReasoner(rules=rules, min_similarity_threshold=0.9)
 By default, the SLDReasoner will abort proofs after a depth of 10. You can customize this behavior by passing `max_proof_depth` when creating the reasoner
 
 ```python
-reasoner = SLDReasoner(rules=rules, max_proof_depth=10)
+reasoner = SLDReasoner(knowledge=knowledge, max_proof_depth=10)
 ```
 
 ## Contributing

--- a/fuzzy_reasoner/__init__.py
+++ b/fuzzy_reasoner/__init__.py
@@ -2,7 +2,7 @@ __version__ = "0.2.0"
 
 from .prover.SLDProver import SLDProver
 
-from .types import Atom, Constant, Predicate, Rule, Variable
+from .types import Atom, Constant, Predicate, Rule, Variable, Knowledge
 
 from .similarity import cosine_similarity, symbol_compare
 
@@ -11,6 +11,7 @@ __all__ = (
     "Atom",
     "Constant",
     "Predicate",
+    "Knowledge",
     "Rule",
     "Variable",
     "cosine_similarity",

--- a/fuzzy_reasoner/types/Knowledge.py
+++ b/fuzzy_reasoner/types/Knowledge.py
@@ -1,0 +1,7 @@
+from typing import Iterable, Union
+
+from .Atom import Atom
+from .Rule import Rule
+
+"Typing helper for the knowledge param of solvers"
+Knowledge = Iterable[Union[Atom, Rule]]

--- a/fuzzy_reasoner/types/__init__.py
+++ b/fuzzy_reasoner/types/__init__.py
@@ -3,11 +3,6 @@ from .Constant import Constant
 from .Predicate import Predicate
 from .Rule import Rule
 from .Variable import Variable
+from .Knowledge import Knowledge
 
-__all__ = (
-    "Atom",
-    "Constant",
-    "Predicate",
-    "Rule",
-    "Variable",
-)
+__all__ = ("Atom", "Constant", "Predicate", "Rule", "Variable", "Knowledge")

--- a/tests/prover/test_SLDProver.py
+++ b/tests/prover/test_SLDProver.py
@@ -23,7 +23,7 @@ def test_basic_proof_without_fuzzy_unification() -> None:
     grandpa_of_def = Rule(grandpa_of(X, Y), (father_of(X, Z), parent_of(Z, Y)))
     grandma_of_def = Rule(grandma_of(X, Y), (mother_of(X, Z), parent_of(Z, Y)))
 
-    rules = [
+    knowledge = [
         # base facts
         Rule(parent_of(homer, bart)),
         Rule(parent_of(marge, bart)),
@@ -34,7 +34,7 @@ def test_basic_proof_without_fuzzy_unification() -> None:
         grandma_of_def,
     ]
 
-    prover = SLDProver(rules=rules)
+    prover = SLDProver(knowledge=knowledge)
     goal = grandpa_of(abe, bart)
 
     proof = prover.prove(goal)
@@ -64,7 +64,7 @@ def test_basic_proof_without_fuzzy_unification() -> None:
     assert prover.prove(grandpa_of(bart, abe)) is None
 
 
-def test_can_use_composite_rules() -> None:
+def test_can_use_composite_knowledge() -> None:
     X = Variable("X")
     Y = Variable("Y")
     Z = Variable("Z")
@@ -81,7 +81,7 @@ def test_can_use_composite_rules() -> None:
     grandpa_of_def = Rule(grandpa_of(X, Y), (father_of(X, Z), parent_of(Z, Y)))
     father_of_def = Rule(father_of(X, Y), (parent_of(X, Y), is_male(X)))
 
-    rules = [
+    knowledge = [
         # base facts
         Rule(parent_of(homer, bart)),
         Rule(parent_of(abe, homer)),
@@ -94,7 +94,7 @@ def test_can_use_composite_rules() -> None:
         father_of_def,
     ]
 
-    prover = SLDProver(rules=rules)
+    prover = SLDProver(knowledge=knowledge)
     goal = grandpa_of(abe, bart)
 
     result = prover.prove(goal)
@@ -113,7 +113,7 @@ def test_can_use_recursive_theorems() -> None:
     d = Constant("d")
     e = Constant("e")
 
-    rules = [
+    knowledge = [
         # base facts
         Rule(parent_of(a, b)),
         Rule(parent_of(b, c)),
@@ -124,7 +124,7 @@ def test_can_use_recursive_theorems() -> None:
         Rule(ancestor_of(X, Y), (parent_of(X, Y),)),
     ]
 
-    prover = SLDProver(rules=rules)
+    prover = SLDProver(knowledge=knowledge)
 
     assert prover.prove(ancestor_of(a, b)) is not None
     assert prover.prove(ancestor_of(a, c)) is not None
@@ -155,7 +155,7 @@ def test_can_solve_for_variable_values() -> None:
     grandpa_of_def = Rule(grandpa_of(X, Y), (father_of(X, Z), parent_of(Z, Y)))
     grandma_of_def = Rule(grandma_of(X, Y), (mother_of(X, Z), parent_of(Z, Y)))
 
-    rules = [
+    knowledge = [
         # base facts
         Rule(parent_of(homer, bart)),
         Rule(parent_of(marge, bart)),
@@ -166,7 +166,7 @@ def test_can_solve_for_variable_values() -> None:
         grandma_of_def,
     ]
 
-    prover = SLDProver(rules=rules)
+    prover = SLDProver(knowledge=knowledge)
     single_var_goal = grandpa_of(X, bart)
 
     result = prover.prove(single_var_goal)
@@ -203,7 +203,7 @@ def test_prove_all_can_find_multiple_solutions_with() -> None:
 
     grandpa_of_def = Rule(grandpa_of(X, Y), (father_of(X, Z), parent_of(Z, Y)))
 
-    rules = [
+    knowledge = [
         # base facts
         Rule(parent_of(homer, bart)),
         Rule(parent_of(marge, bart)),
@@ -213,7 +213,7 @@ def test_prove_all_can_find_multiple_solutions_with() -> None:
         grandpa_of_def,
     ]
 
-    prover = SLDProver(rules=rules)
+    prover = SLDProver(knowledge=knowledge)
 
     goal = grandpa_of(X, bart)
 

--- a/tests/test_fuzzy_reasoner.py
+++ b/tests/test_fuzzy_reasoner.py
@@ -6,6 +6,7 @@ from fuzzy_reasoner import (
     Predicate,
     Rule,
     Variable,
+    Knowledge,
     cosine_similarity,
     symbol_compare,
 )
@@ -31,13 +32,13 @@ def test_basic_proof() -> None:
     bart = Constant("bart")
     homer = Constant("homer")
 
-    rules = [
-        Rule(parent_of(homer, bart)),
-        Rule(is_male(homer)),
+    knowledge: Knowledge = [
+        parent_of(homer, bart),
+        is_male(homer),
         Rule(father_of(X, Y), (parent_of(X, Y), is_male(X))),
     ]
 
-    prover = SLDProver(rules=rules)
+    prover = SLDProver(knowledge=knowledge)
     goal = father_of(homer, X)
 
     proof = prover.prove(goal)


### PR DESCRIPTION
This PR renames the `rules` param to `knowledge` to better represent its role as a "knowledge base", and allows using plain `Atom`s instead of requiring everything to be wrapped as a `Rule`.